### PR TITLE
Allow for CPT permalink structure

### DIFF
--- a/be-subpages-widget.php
+++ b/be-subpages-widget.php
@@ -130,7 +130,7 @@ class BE_Subpages_Widget extends WP_Widget {
 			$class = apply_filters( 'be_subpages_widget_class', $class, $subpage );
 			$class = !empty( $class ) ? ' class="' . implode( ' ', $class ) . '"' : '';
 
-			echo '<li' . $class . '><a href="' . get_page_link( $subpage->ID ) . '">' . apply_filters( 'be_subpages_page_title', $subpage->post_title ) . '</a>';
+			echo '<li' . $class . '><a href="' . get_permalink( $subpage->ID ) . '">' . apply_filters( 'be_subpages_page_title', $subpage->post_title ) . '</a>';
 			// If nesting supress the closing li
 			if (!$nest_subpages)
 				echo '</li>';


### PR DESCRIPTION
I'm filtering be_subpages_widget_args to switch the post_type out. Switching to get_permalink resolves an issue where my post type's permalinks are missing their base slug.
